### PR TITLE
fix email verification codes instantly expiring

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -44,7 +44,9 @@ const CONSTANTS = {
         getIP: [false, true],
         getDeviceType: [false, true],
         getLocation: [false, true]
-    }
+    },
+    EMAIL_VERIFICATION_CODE_SALT_ROUNDS: 10,
+    EMAIL_VERIFICATION_CODE_EXPIRE_TIME_SECONDS: 60 * 5 //5 minutes
 }
 
 module.exports = CONSTANTS

--- a/controllers/Temp.js
+++ b/controllers/Temp.js
@@ -33,6 +33,11 @@ const threadPostHandler = new ThreadPostLibrary();
 const ArrayLibrary = require('../libraries/Array');
 const arrayHelper = new ArrayLibrary();
 
+const UserLibrary = require('../libraries/User')
+const userHandler = new UserLibrary();
+
+const bcrypt = require('bcrypt')
+
 const { sendNotifications } = require("../notificationHandler");
 
 const { blurEmailFunction, mailTransporter } = require('../globalFunctions.js');
@@ -227,7 +232,7 @@ class TempController {
                                     const newRefreshToken = new RefreshToken(newRefreshTokenObject)
         
                                     newRefreshToken.save().then(() => {
-                                        RefreshToken.deleteMany({encryptedRefreshToken: {$not: encryptedRefreshToken}, userId: result._id, admin: false}).then(() => {
+                                        RefreshToken.deleteMany({encryptedRefreshToken: {$ne: encryptedRefreshToken}, userId: data._id, admin: false}).then(() => {
                                             User.findOneAndUpdate({_id: {$eq: userId}}, {password: hashedPassword}).then(() => {
                                                 return resolve(HTTPWTHandler.OK('Changing password was a success!', {}, {token: `Bearer ${token}`, refreshToken: `Bearer ${refreshToken}`}))
                                             }).catch(error => {
@@ -235,7 +240,7 @@ class TempController {
                                                 return resolve(HTTPWTHandler.serverError('An error occurred while changing password. Please try again.'))
                                             })
                                         }).catch(error => {
-                                            console.error('An error occurred while deleting all RefreshTokens that have a userId of:', result._id, 'and that do not have an encryptedRefreshToken:', encryptedRefreshToken, '. The error was:', error)
+                                            console.error('An error occurred while deleting all RefreshTokens that have a userId of:', data._id, 'and that do not have an encryptedRefreshToken:', encryptedRefreshToken, '. The error was:', error)
                                             return resolve(HTTPWTHandler.serverError('An error occurred while invalidating all other sessions. Please manually log out all other users from your account.'))
                                         })
                                     }).catch(error => {

--- a/models/EmailVerificationCode.js
+++ b/models/EmailVerificationCode.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+const CONSTANTS = require('../constants');
+const Schema = mongoose.Schema;
+
+const EmailVerificationCodeSchema = new Schema({
+    createdAt: {
+        type: Date,
+        expires: CONSTANTS.EMAIL_VERIFICATION_CODE_EXPIRE_TIME_SECONDS,
+        default: Date.now, //Creates a new UNIX Epoch milliseconds timestamp on document creation
+        required: true
+    },
+    userId: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true
+    },
+    hashedVerificationCode: {
+        type: String,
+        required: true
+    }
+});
+
+const EmailVerificationCode = mongoose.model('EmailVerificationCode', EmailVerificationCodeSchema);
+
+module.exports = EmailVerificationCode;


### PR DESCRIPTION
The previous way of storing email verification codes was in an in-memory cache. That worked well for when the server was single-threaded, but now that each server request has it's own thread created to do the work, the email verification codes no longer work.

The fix to that problem was to move email verification codes to the database, and give them a 5 minute TTL so they expire after 5 minutes of being created.