### PR TITLE
commentId from temp/getImagesFromProfile is now stringified before being sent

### DIFF
--- a/libraries/ImagePost.js
+++ b/libraries/ImagePost.js
@@ -28,7 +28,8 @@ class ImagePostClass {
                                 downvoted: !!isDownvoted,
                                 isOwner: postOwner._id.toString() === userRequesting._id.toString(),
                                 interacted: !!isUpvoted || !!isDownvoted,
-                                _id: post._id.toString()
+                                _id: post._id.toString(),
+                                comments: post.comments ? post.comments.map(comment => ({...comment, commentId: String(comment.commentId)})) : []
                             })
                         }).catch(error => {
                             reject(`An error occured while executing Promise.all in ImagePostLibrary.processMultiplePostDataFromOneOwner: ${error}`)


### PR DESCRIPTION
This allows it to be serialised properly when the data is getting sent to the main thread.