### PR TITLE
Fix logging into some accounts failed

### DIFF
--- a/controllers/User.js
+++ b/controllers/User.js
@@ -181,7 +181,7 @@ class UserController {
                         bcrypt.compare(password, hashedPassword).then(async (result) => {
                                 if (result) {
                                     // Password match
-                                    if (data.authenticationFactorsEnabled.includes('Email')) {
+                                    if (data.authenticationFactorsEnabled?.includes('Email')) {
                                         try {
                                             var randomString = await axios.get('https://www.random.org/integers/?num=1&min=1&max=1000000000&col=1&base=16&format=plain&rnd=new')
                                             randomString = String(randomString.data).trim();


### PR DESCRIPTION
The reason why it was failing was because the server was trying to see if userObj.authenticationFactorsEnabled.includes('Email'). A user in the database doesn't have an authenticationFactorsEnabled field unless they enable another authentication factor.

That meant for accounts that didn't enable any other authentication factors before could not login to their accounts.

The fix was to add a ? after the authenticationFactorsEnabled part, so if authenticationFactorsEnabled is undefined, it ignores it instead of throwing an error.