### PR TITLE
Add HTTP headers sent twice bug prevention

### DIFF
--- a/routes/Temp.js
+++ b/routes/Temp.js
@@ -879,6 +879,7 @@ const rateLimiters = {
 
 
 router.post('/sendnotificationkey', rateLimiters['/sendnotificationkey'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'sendnotificationkey',
@@ -887,7 +888,12 @@ router.post('/sendnotificationkey', rateLimiters['/sendnotificationkey'], (req, 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('POST temp/sendnotificationkey controller function returned data to be sent to the client but HTTP headers have already been sent!')
+        }
     })
 
     worker.on('error', (error) => {
@@ -897,6 +903,7 @@ router.post('/sendnotificationkey', rateLimiters['/sendnotificationkey'], (req, 
 });
 
 router.post('/changedisplayname', rateLimiters['/changedisplayname'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'changedisplayname',
@@ -905,7 +912,12 @@ router.post('/changedisplayname', rateLimiters['/changedisplayname'], (req, res)
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('POST temp/changedisplayname controller function returned data to be sent to the client but HTTP headers have already been sent!')
+        }
     })
 
     worker.on('error', (error) => {
@@ -915,6 +927,7 @@ router.post('/changedisplayname', rateLimiters['/changedisplayname'], (req, res)
 });
 
 router.post('/changeemail', rateLimiters['/changeemail'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'changedisplayname',
@@ -923,7 +936,12 @@ router.post('/changeemail', rateLimiters['/changeemail'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('POST temp/changeemail controller function returned data to be sent to the client but HTTP headers have already been sent!')
+        }
     })
 
     worker.on('error', (error) => {
@@ -933,6 +951,7 @@ router.post('/changeemail', rateLimiters['/changeemail'], (req, res) => {
 });
 
 router.post('/changepassword', rateLimiters['/changepassword'], HTTPHandler.getDeviceTypeMiddleware(), (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'changepassword',
@@ -941,7 +960,12 @@ router.post('/changepassword', rateLimiters['/changepassword'], HTTPHandler.getD
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -951,6 +975,7 @@ router.post('/changepassword', rateLimiters['/changepassword'], HTTPHandler.getD
 });
 
 router.post('/changeusername', rateLimiters['/changeusername'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'changeusername',
@@ -959,7 +984,12 @@ router.post('/changeusername', rateLimiters['/changeusername'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -977,7 +1007,12 @@ router.post('/changebio', rateLimiters['/changebio'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -987,6 +1022,7 @@ router.post('/changebio', rateLimiters['/changebio'], (req, res) => {
 });
 
 router.post('/searchpageusersearch', rateLimiters['/searchpageusersearch'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchpageusersearch',
@@ -995,7 +1031,12 @@ router.post('/searchpageusersearch', rateLimiters['/searchpageusersearch'], (req
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1005,6 +1046,7 @@ router.post('/searchpageusersearch', rateLimiters['/searchpageusersearch'], (req
 });
 
 router.post('/createpollpost', rateLimiters['/createpollpost'], (req, res) => {
+    let HTTPHeadersSent = false;
     let {pollTitle, pollSubTitle, optionOne, optionOnesColor, optionTwo, optionTwosColor, optionThree, optionThreesColor, optionFour, optionFoursColor, optionFive, optionFivesColor, optionSix, optionSixesColor, totalNumberOfOptions, sentAllowScreenShots} = req.body;
 
     const worker = new Worker(workerPath, {
@@ -1033,7 +1075,12 @@ router.post('/createpollpost', rateLimiters['/createpollpost'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1043,6 +1090,7 @@ router.post('/createpollpost', rateLimiters['/createpollpost'], (req, res) => {
 });
 
 router.post('/searchforpollposts', rateLimiters['/searchforpollposts'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchforpollposts',
@@ -1051,7 +1099,12 @@ router.post('/searchforpollposts', rateLimiters['/searchforpollposts'], (req, re
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1061,6 +1114,7 @@ router.post('/searchforpollposts', rateLimiters['/searchforpollposts'], (req, re
 });
 
 router.post('/pollpostcomment', rateLimiters['/pollpostcomment'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'pollpostcomment',
@@ -1069,7 +1123,12 @@ router.post('/pollpostcomment', rateLimiters['/pollpostcomment'], (req, res) => 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1079,6 +1138,7 @@ router.post('/pollpostcomment', rateLimiters['/pollpostcomment'], (req, res) => 
 });
 
 router.post('/pollpostcommentreply', rateLimiters['/pollpostcommentreply'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'pollpostcommentreply',
@@ -1087,7 +1147,12 @@ router.post('/pollpostcommentreply', rateLimiters['/pollpostcommentreply'], (req
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1097,6 +1162,7 @@ router.post('/pollpostcommentreply', rateLimiters['/pollpostcommentreply'], (req
 });
 
 router.post('/searchforpollcomments', rateLimiters['/searchforpollcomments'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchforpollcomments',
@@ -1105,7 +1171,12 @@ router.post('/searchforpollcomments', rateLimiters['/searchforpollcomments'], (r
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1115,6 +1186,7 @@ router.post('/searchforpollcomments', rateLimiters['/searchforpollcomments'], (r
 });
 
 router.post('/voteonpoll', rateLimiters['/voteonpoll'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'voteonpoll',
@@ -1123,7 +1195,12 @@ router.post('/voteonpoll', rateLimiters['/voteonpoll'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1133,6 +1210,7 @@ router.post('/voteonpoll', rateLimiters['/voteonpoll'], (req, res) => {
 });
 
 router.post('/removevoteonpoll', rateLimiters['/removevoteonpoll'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'removevoteonpoll',
@@ -1141,7 +1219,12 @@ router.post('/removevoteonpoll', rateLimiters['/removevoteonpoll'], (req, res) =
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1151,6 +1234,7 @@ router.post('/removevoteonpoll', rateLimiters['/removevoteonpoll'], (req, res) =
 });
 
 router.post('/searchforpollpostsbyid', rateLimiters['/searchforpollpostsbyid'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchforpollpostsbyid',
@@ -1159,7 +1243,12 @@ router.post('/searchforpollpostsbyid', rateLimiters['/searchforpollpostsbyid'], 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1169,6 +1258,7 @@ router.post('/searchforpollpostsbyid', rateLimiters['/searchforpollpostsbyid'], 
 });
 
 router.post('/upvotepoll', rateLimiters['/upvotepoll'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'upvotepoll',
@@ -1177,7 +1267,12 @@ router.post('/upvotepoll', rateLimiters['/upvotepoll'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1187,6 +1282,7 @@ router.post('/upvotepoll', rateLimiters['/upvotepoll'], (req, res) => {
 });
 
 router.post('/downvotepoll', rateLimiters['/downvotepoll'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'downvotepoll',
@@ -1195,7 +1291,12 @@ router.post('/downvotepoll', rateLimiters['/downvotepoll'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1205,6 +1306,7 @@ router.post('/downvotepoll', rateLimiters['/downvotepoll'], (req, res) => {
 });
 
 router.post('/getsinglepollcomment', rateLimiters['/getsinglepollcomment'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getsinglepollcomment',
@@ -1213,7 +1315,12 @@ router.post('/getsinglepollcomment', rateLimiters['/getsinglepollcomment'], (req
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1223,6 +1330,7 @@ router.post('/getsinglepollcomment', rateLimiters['/getsinglepollcomment'], (req
 });
 
 router.post('/searchforpollcommentreplies', rateLimiters['/searchforpollcommentreplies'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchforpollcommentreplies',
@@ -1231,7 +1339,12 @@ router.post('/searchforpollcommentreplies', rateLimiters['/searchforpollcommentr
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1241,6 +1354,7 @@ router.post('/searchforpollcommentreplies', rateLimiters['/searchforpollcommentr
 });
 
 router.post('/deletepoll', rateLimiters['/deletepoll'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'deletepoll',
@@ -1249,7 +1363,12 @@ router.post('/deletepoll', rateLimiters['/deletepoll'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1259,6 +1378,7 @@ router.post('/deletepoll', rateLimiters['/deletepoll'], (req, res) => {
 });
 
 router.post('/postImage', rateLimiters['/postImage'], upload.single('image'), async (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'postImage',
@@ -1267,7 +1387,12 @@ router.post('/postImage', rateLimiters['/postImage'], upload.single('image'), as
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1277,6 +1402,7 @@ router.post('/postImage', rateLimiters['/postImage'], upload.single('image'), as
 });
 
 router.post('/postProfileImage', rateLimiters['/postProfileImage'], upload.single('image'), async (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'postProfileImage',
@@ -1285,7 +1411,12 @@ router.post('/postProfileImage', rateLimiters['/postProfileImage'], upload.singl
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1295,6 +1426,7 @@ router.post('/postProfileImage', rateLimiters['/postProfileImage'], upload.singl
 });
 
 router.post('/getImagesFromProfile', rateLimiters['/getImagesFromProfile'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getImagesFromProfile',
@@ -1303,7 +1435,12 @@ router.post('/getImagesFromProfile', rateLimiters['/getImagesFromProfile'], (req
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1313,6 +1450,7 @@ router.post('/getImagesFromProfile', rateLimiters['/getImagesFromProfile'], (req
 });
 
 router.get('/getProfilePic/:pubId', rateLimiters['/getProfilePic/:pubId'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getProfilePic',
@@ -1321,7 +1459,12 @@ router.get('/getProfilePic/:pubId', rateLimiters['/getProfilePic/:pubId'], (req,
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1331,6 +1474,7 @@ router.get('/getProfilePic/:pubId', rateLimiters['/getProfilePic/:pubId'], (req,
 });
 
 router.post('/imagepostcomment', rateLimiters['/imagepostcomment'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'imagepostcomment',
@@ -1339,7 +1483,12 @@ router.post('/imagepostcomment', rateLimiters['/imagepostcomment'], (req, res) =
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1349,6 +1498,7 @@ router.post('/imagepostcomment', rateLimiters['/imagepostcomment'], (req, res) =
 });
 
 router.post('/imagepostcommentreply', rateLimiters['/imagepostcommentreply'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'imagepostcommentreply',
@@ -1357,7 +1507,12 @@ router.post('/imagepostcommentreply', rateLimiters['/imagepostcommentreply'], (r
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1367,6 +1522,7 @@ router.post('/imagepostcommentreply', rateLimiters['/imagepostcommentreply'], (r
 });
 
 router.post('/getimagepostcomments', rateLimiters['/getimagepostcomments'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getimagepostcomments',
@@ -1375,7 +1531,12 @@ router.post('/getimagepostcomments', rateLimiters['/getimagepostcomments'], (req
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1385,6 +1546,7 @@ router.post('/getimagepostcomments', rateLimiters['/getimagepostcomments'], (req
 });
 
 router.post('/upvoteimage', rateLimiters['/upvoteimage'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'upvoteimage',
@@ -1393,7 +1555,12 @@ router.post('/upvoteimage', rateLimiters['/upvoteimage'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1403,6 +1570,7 @@ router.post('/upvoteimage', rateLimiters['/upvoteimage'], (req, res) => {
 });
 
 router.post('/downvoteimage', rateLimiters['/downvoteimage'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'downvoteimage',
@@ -1411,7 +1579,12 @@ router.post('/downvoteimage', rateLimiters['/downvoteimage'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1421,6 +1594,7 @@ router.post('/downvoteimage', rateLimiters['/downvoteimage'], (req, res) => {
 });
 
 router.post('/getsingleimagecomment', rateLimiters['/getsingleimagecomment'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getsingleimagecomment',
@@ -1429,7 +1603,12 @@ router.post('/getsingleimagecomment', rateLimiters['/getsingleimagecomment'], (r
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1439,6 +1618,7 @@ router.post('/getsingleimagecomment', rateLimiters['/getsingleimagecomment'], (r
 });
 
 router.post('/searchforimagecommentreplies', rateLimiters['/searchforimagecommentreplies'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchforimagecommentreplies',
@@ -1447,7 +1627,12 @@ router.post('/searchforimagecommentreplies', rateLimiters['/searchforimagecommen
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1457,6 +1642,7 @@ router.post('/searchforimagecommentreplies', rateLimiters['/searchforimagecommen
 });
 
 router.post('/postcategorywithimage', rateLimiters['/postcategorywithimage'], upload.single('image'), async (req, res) => {
+    let HTTPHeadersSent = false;
     let {categoryTitle, categoryDescription, categoryTags, categoryNSFW, categoryNSFL, sentAllowScreenShots} = req.body;
     const worker = new Worker(workerPath, {
         workerData: {
@@ -1466,7 +1652,12 @@ router.post('/postcategorywithimage', rateLimiters['/postcategorywithimage'], up
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1476,6 +1667,7 @@ router.post('/postcategorywithimage', rateLimiters['/postcategorywithimage'], up
 });
 
 router.post('/deleteimage', rateLimiters['/deleteimage'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'deleteimage',
@@ -1484,7 +1676,12 @@ router.post('/deleteimage', rateLimiters['/deleteimage'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1494,6 +1691,7 @@ router.post('/deleteimage', rateLimiters['/deleteimage'], (req, res) => {
 });
 
 router.post('/postcategorywithoutimage', rateLimiters['/postcategorywithoutimage'], (req, res) => {
+    let HTTPHeadersSent = false;
     let {categoryTitle, categoryDescription, categoryTags, categoryNSFW, categoryNSFL, sentAllowScreenShots} = req.body;
     const worker = new Worker(workerPath, {
         workerData: {
@@ -1503,7 +1701,12 @@ router.post('/postcategorywithoutimage', rateLimiters['/postcategorywithoutimage
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1513,6 +1716,7 @@ router.post('/postcategorywithoutimage', rateLimiters['/postcategorywithoutimage
 });
 
 router.post('/searchpagesearchcategories', rateLimiters['/searchpagesearchcategories'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchpagesearchcategories',
@@ -1521,7 +1725,12 @@ router.post('/searchpagesearchcategories', rateLimiters['/searchpagesearchcatego
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1531,6 +1740,7 @@ router.post('/searchpagesearchcategories', rateLimiters['/searchpagesearchcatego
 });
 
 router.post('/getcategoryimage', rateLimiters['/getcategoryimage'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getcategoryimage',
@@ -1539,7 +1749,12 @@ router.post('/getcategoryimage', rateLimiters['/getcategoryimage'], (req, res) =
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1549,6 +1764,7 @@ router.post('/getcategoryimage', rateLimiters['/getcategoryimage'], (req, res) =
 });
 
 router.post('/findcategorybyid', rateLimiters['/findcategorybyid'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'findcategorybyid',
@@ -1557,7 +1773,12 @@ router.post('/findcategorybyid', rateLimiters['/findcategorybyid'], (req, res) =
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1567,6 +1788,7 @@ router.post('/findcategorybyid', rateLimiters['/findcategorybyid'], (req, res) =
 });
 
 router.post('/findcategoryfromprofile', rateLimiters['/findcategoryfromprofile'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'findcategoryfromprofile',
@@ -1575,7 +1797,12 @@ router.post('/findcategoryfromprofile', rateLimiters['/findcategoryfromprofile']
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1585,6 +1812,7 @@ router.post('/findcategoryfromprofile', rateLimiters['/findcategoryfromprofile']
 });
 
 router.post('/joincategory', rateLimiters['/joincategory'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'joincategory',
@@ -1593,7 +1821,12 @@ router.post('/joincategory', rateLimiters['/joincategory'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1603,6 +1836,7 @@ router.post('/joincategory', rateLimiters['/joincategory'], (req, res) => {
 });
 
 router.post('/posttextthread', rateLimiters['/posttextthread'], (req, res) => {
+    let HTTPHeadersSent = false;
     let {threadTitle, threadSubtitle, threadTags, threadCategoryId, threadBody, threadNSFW, threadNSFL, sentAllowScreenShots} = req.body;
 
     const worker = new Worker(workerPath, {
@@ -1613,7 +1847,12 @@ router.post('/posttextthread', rateLimiters['/posttextthread'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1623,6 +1862,7 @@ router.post('/posttextthread', rateLimiters['/posttextthread'], (req, res) => {
 });
 
 router.post('/postimagethread', rateLimiters['/postimagethread'], upload.single('image'), async (req, res) => {
+    let HTTPHeadersSent = false;
     let {threadTitle, threadSubtitle, threadTags, threadCategoryId, threadImageDescription, threadNSFW, threadNSFL, sentAllowScreenShots} = req.body;
     const worker = new Worker(workerPath, {
         workerData: {
@@ -1632,7 +1872,12 @@ router.post('/postimagethread', rateLimiters['/postimagethread'], upload.single(
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1642,6 +1887,7 @@ router.post('/postimagethread', rateLimiters['/postimagethread'], upload.single(
 });
 
 router.post('/getthreadsfromcategory', rateLimiters['/getthreadsfromcategory'], (req, res) => {
+    let HTTPHeadersSent = false;
     let {categoryId} = req.body;
 
     const worker = new Worker(workerPath, {
@@ -1652,7 +1898,12 @@ router.post('/getthreadsfromcategory', rateLimiters['/getthreadsfromcategory'], 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1662,6 +1913,7 @@ router.post('/getthreadsfromcategory', rateLimiters['/getthreadsfromcategory'], 
 });
 
 router.post('/getthreadsfromprofile', rateLimiters['/getthreadsfromprofile'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getthreadsfromprofile',
@@ -1670,7 +1922,12 @@ router.post('/getthreadsfromprofile', rateLimiters['/getthreadsfromprofile'], (r
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1680,6 +1937,7 @@ router.post('/getthreadsfromprofile', rateLimiters['/getthreadsfromprofile'], (r
 });
 
 router.post('/upvotethread', rateLimiters['/upvotethread'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'upvotethread',
@@ -1688,7 +1946,12 @@ router.post('/upvotethread', rateLimiters['/upvotethread'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1698,6 +1961,7 @@ router.post('/upvotethread', rateLimiters['/upvotethread'], (req, res) => {
 });
 
 router.post('/downvotethread', rateLimiters['/downvotethread'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'downvotethread',
@@ -1706,7 +1970,12 @@ router.post('/downvotethread', rateLimiters['/downvotethread'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1716,6 +1985,7 @@ router.post('/downvotethread', rateLimiters['/downvotethread'], (req, res) => {
 });
 
 router.post('/threadpostcomment', rateLimiters['/threadpostcomment'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'threadpostcomment',
@@ -1724,7 +1994,12 @@ router.post('/threadpostcomment', rateLimiters['/threadpostcomment'], (req, res)
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1734,6 +2009,7 @@ router.post('/threadpostcomment', rateLimiters['/threadpostcomment'], (req, res)
 });
 
 router.post('/threadpostcommentreply', rateLimiters['/threadpostcommentreply'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'threadpostcommentreply',
@@ -1742,7 +2018,12 @@ router.post('/threadpostcommentreply', rateLimiters['/threadpostcommentreply'], 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1752,6 +2033,7 @@ router.post('/threadpostcommentreply', rateLimiters['/threadpostcommentreply'], 
 });
 
 router.post('/searchforthreadcomments', rateLimiters['/searchforthreadcomments'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchforthreadcomments',
@@ -1760,7 +2042,12 @@ router.post('/searchforthreadcomments', rateLimiters['/searchforthreadcomments']
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1770,6 +2057,7 @@ router.post('/searchforthreadcomments', rateLimiters['/searchforthreadcomments']
 });
 
 router.post('/getsinglethreadcomment', rateLimiters['/getsinglethreadcomment'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getsinglethreadcomment',
@@ -1778,7 +2066,12 @@ router.post('/getsinglethreadcomment', rateLimiters['/getsinglethreadcomment'], 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1788,6 +2081,7 @@ router.post('/getsinglethreadcomment', rateLimiters['/getsinglethreadcomment'], 
 });
 
 router.post('/searchforthreadcommentreplies', rateLimiters['/searchforthreadcommentreplies'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'searchforthreadcommentreplies',
@@ -1796,7 +2090,12 @@ router.post('/searchforthreadcommentreplies', rateLimiters['/searchforthreadcomm
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1806,6 +2105,7 @@ router.post('/searchforthreadcommentreplies', rateLimiters['/searchforthreadcomm
 });
 
 router.post('/getthreadbyid', rateLimiters['/getthreadbyid'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getthreadbyid',
@@ -1814,7 +2114,12 @@ router.post('/getthreadbyid', rateLimiters['/getthreadbyid'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1824,6 +2129,7 @@ router.post('/getthreadbyid', rateLimiters['/getthreadbyid'], (req, res) => {
 });
 
 router.post('/deletethread', rateLimiters['/deletethread'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'deletethread',
@@ -1832,7 +2138,12 @@ router.post('/deletethread', rateLimiters['/deletethread'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1842,6 +2153,7 @@ router.post('/deletethread', rateLimiters['/deletethread'], (req, res) => {
 });
 
 router.post('/upvotecomment', rateLimiters['/upvotecomment'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'upvotecomment',
@@ -1850,7 +2162,12 @@ router.post('/upvotecomment', rateLimiters['/upvotecomment'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1860,6 +2177,7 @@ router.post('/upvotecomment', rateLimiters['/upvotecomment'], (req, res) => {
 });
 
 router.post('/downvotecomment', rateLimiters['/downvotecomment'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'downvotecomment',
@@ -1868,7 +2186,12 @@ router.post('/downvotecomment', rateLimiters['/downvotecomment'], (req, res) => 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1878,6 +2201,7 @@ router.post('/downvotecomment', rateLimiters['/downvotecomment'], (req, res) => 
 });
 
 router.post('/toggleFollowOfAUser', rateLimiters['/toggleFollowOfAUser'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'toggleFollowOfAUser',
@@ -1886,7 +2210,12 @@ router.post('/toggleFollowOfAUser', rateLimiters['/toggleFollowOfAUser'], (req, 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1896,6 +2225,7 @@ router.post('/toggleFollowOfAUser', rateLimiters['/toggleFollowOfAUser'], (req, 
 });
 
 router.post('/reloadUsersDetails', rateLimiters['/reloadUsersDetails'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'reloadUsersDetails',
@@ -1904,7 +2234,12 @@ router.post('/reloadUsersDetails', rateLimiters['/reloadUsersDetails'], (req, re
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1914,6 +2249,7 @@ router.post('/reloadUsersDetails', rateLimiters['/reloadUsersDetails'], (req, re
 });
 
 router.post('/earnSpecialBadge', rateLimiters['/earnSpecialBadge'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'earnSpecialBadge',
@@ -1922,7 +2258,12 @@ router.post('/earnSpecialBadge', rateLimiters['/earnSpecialBadge'], (req, res) =
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1932,6 +2273,7 @@ router.post('/earnSpecialBadge', rateLimiters['/earnSpecialBadge'], (req, res) =
 });
 
 router.post('/getuserbyid', rateLimiters['/getuserbyid'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getuserbyid',
@@ -1940,7 +2282,12 @@ router.post('/getuserbyid', rateLimiters['/getuserbyid'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1950,6 +2297,7 @@ router.post('/getuserbyid', rateLimiters['/getuserbyid'], (req, res) => {
 });
 
 router.post('/makeaccountprivate', rateLimiters['/makeaccountprivate'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'makeaccountprivate',
@@ -1958,7 +2306,12 @@ router.post('/makeaccountprivate', rateLimiters['/makeaccountprivate'], (req, re
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1968,6 +2321,7 @@ router.post('/makeaccountprivate', rateLimiters['/makeaccountprivate'], (req, re
 });
 
 router.post('/makeaccountpublic', rateLimiters['/makeaccountpublic'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'makeaccountpublic',
@@ -1976,7 +2330,12 @@ router.post('/makeaccountpublic', rateLimiters['/makeaccountpublic'], (req, res)
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -1986,6 +2345,7 @@ router.post('/makeaccountpublic', rateLimiters['/makeaccountpublic'], (req, res)
 });
 
 router.post('/getfollowrequests', rateLimiters['/getfollowrequests'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getfollowrequests',
@@ -1994,7 +2354,12 @@ router.post('/getfollowrequests', rateLimiters['/getfollowrequests'], (req, res)
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2004,6 +2369,7 @@ router.post('/getfollowrequests', rateLimiters['/getfollowrequests'], (req, res)
 });
 
 router.post('/denyfollowrequest', rateLimiters['/denyfollowrequest'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'denyfollowrequest',
@@ -2012,7 +2378,12 @@ router.post('/denyfollowrequest', rateLimiters['/denyfollowrequest'], (req, res)
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2022,6 +2393,7 @@ router.post('/denyfollowrequest', rateLimiters['/denyfollowrequest'], (req, res)
 });
 
 router.post('/acceptfollowrequest', rateLimiters['/acceptfollowrequest'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'acceptfollowrequest',
@@ -2030,7 +2402,12 @@ router.post('/acceptfollowrequest', rateLimiters['/acceptfollowrequest'], (req, 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2040,6 +2417,7 @@ router.post('/acceptfollowrequest', rateLimiters['/acceptfollowrequest'], (req, 
 });
 
 router.post('/removefollowerfromaccount', rateLimiters['/removefollowerfromaccount'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'removefollowerfromaccount',
@@ -2048,7 +2426,12 @@ router.post('/removefollowerfromaccount', rateLimiters['/removefollowerfromaccou
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2058,6 +2441,7 @@ router.post('/removefollowerfromaccount', rateLimiters['/removefollowerfromaccou
 });
 
 router.post('/blockaccount', rateLimiters['/blockaccount'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'blockaccount',
@@ -2066,7 +2450,12 @@ router.post('/blockaccount', rateLimiters['/blockaccount'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2076,6 +2465,7 @@ router.post('/blockaccount', rateLimiters['/blockaccount'], (req, res) => {
 });
 
 router.get('/getuserblockedaccounts', rateLimiters['/getuserblockedaccounts'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getuserblockedaccounts',
@@ -2084,7 +2474,12 @@ router.get('/getuserblockedaccounts', rateLimiters['/getuserblockedaccounts'], (
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2094,6 +2489,7 @@ router.get('/getuserblockedaccounts', rateLimiters['/getuserblockedaccounts'], (
 });
 
 router.post('/unblockaccount', rateLimiters['/unblockaccount'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'unblockaccount',
@@ -2102,7 +2498,12 @@ router.post('/unblockaccount', rateLimiters['/unblockaccount'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2112,6 +2513,7 @@ router.post('/unblockaccount', rateLimiters['/unblockaccount'], (req, res) => {
 });
 
 router.post('/enableAlgorithm', rateLimiters['/enableAlgorithm'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'enableAlgorithm',
@@ -2120,7 +2522,12 @@ router.post('/enableAlgorithm', rateLimiters['/enableAlgorithm'], (req, res) => 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2130,6 +2537,7 @@ router.post('/enableAlgorithm', rateLimiters['/enableAlgorithm'], (req, res) => 
 });
 
 router.get('/getAuthenticationFactorsEnabled', rateLimiters['/getAuthenticationFactorsEnabled'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getAuthenticationFactorsEnabled',
@@ -2138,7 +2546,12 @@ router.get('/getAuthenticationFactorsEnabled', rateLimiters['/getAuthenticationF
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2148,6 +2561,7 @@ router.get('/getAuthenticationFactorsEnabled', rateLimiters['/getAuthenticationF
 });
 
 router.post('/disableAlgorithm', rateLimiters['/disableAlgorithm'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'disableAlgorithm',
@@ -2156,7 +2570,12 @@ router.post('/disableAlgorithm', rateLimiters['/disableAlgorithm'], (req, res) =
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2166,6 +2585,7 @@ router.post('/disableAlgorithm', rateLimiters['/disableAlgorithm'], (req, res) =
 });
 
 router.post('/reloadProfileEssentials', rateLimiters['/reloadProfileEssentials'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'reloadProfileEssentials',
@@ -2174,7 +2594,12 @@ router.post('/reloadProfileEssentials', rateLimiters['/reloadProfileEssentials']
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2184,6 +2609,7 @@ router.post('/reloadProfileEssentials', rateLimiters['/reloadProfileEssentials']
 });
 
 router.post('/turnOffEmailMultiFactorAuthentication', rateLimiters['/turnOffEmailMultiFactorAuthentication'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'turnOffEmailMultiFactorAuthentication',
@@ -2192,7 +2618,12 @@ router.post('/turnOffEmailMultiFactorAuthentication', rateLimiters['/turnOffEmai
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2202,6 +2633,7 @@ router.post('/turnOffEmailMultiFactorAuthentication', rateLimiters['/turnOffEmai
 });
 
 router.post('/deleteaccount', rateLimiters['/deleteaccount'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'deleteaccount',
@@ -2210,7 +2642,12 @@ router.post('/deleteaccount', rateLimiters['/deleteaccount'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2220,6 +2657,7 @@ router.post('/deleteaccount', rateLimiters['/deleteaccount'], (req, res) => {
 });
 
 router.post('/checkIfCategoryExists', rateLimiters['/checkIfCategoryExists'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'checkIfCategoryExists',
@@ -2228,7 +2666,12 @@ router.post('/checkIfCategoryExists', rateLimiters['/checkIfCategoryExists'], (r
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2238,6 +2681,7 @@ router.post('/checkIfCategoryExists', rateLimiters['/checkIfCategoryExists'], (r
 });
 
 router.post('/uploadNotificationsSettings', rateLimiters['/uploadNotificationsSettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'uploadNotificationsSettings',
@@ -2246,7 +2690,12 @@ router.post('/uploadNotificationsSettings', rateLimiters['/uploadNotificationsSe
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2256,6 +2705,7 @@ router.post('/uploadNotificationsSettings', rateLimiters['/uploadNotificationsSe
 });
 
 router.get('/getUserNotificationSettings', rateLimiters['/getUserNotificationSettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getUserNotificationSettings',
@@ -2264,7 +2714,12 @@ router.get('/getUserNotificationSettings', rateLimiters['/getUserNotificationSet
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2274,6 +2729,7 @@ router.get('/getUserNotificationSettings', rateLimiters['/getUserNotificationSet
 });
 
 router.post('/reportUser', rateLimiters['/reportUser'], (req, res) => {
+    let HTTPHeadersSent = false;
     let {reportType, reporteePubId} = req.body;
     const worker = new Worker(workerPath, {
         workerData: {
@@ -2283,7 +2739,12 @@ router.post('/reportUser', rateLimiters['/reportUser'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2293,6 +2754,7 @@ router.post('/reportUser', rateLimiters['/reportUser'], (req, res) => {
 });
 
 router.post('/getUserActivity', rateLimiters['/getUserActivity'], (req, res) => {
+    let HTTPHeadersSent = false;
     let {skip, voteType, postFormat} = req.body;
     const worker = new Worker(workerPath, {
         workerData: {
@@ -2302,7 +2764,12 @@ router.post('/getUserActivity', rateLimiters['/getUserActivity'], (req, res) => 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2312,6 +2779,7 @@ router.post('/getUserActivity', rateLimiters['/getUserActivity'], (req, res) => 
 });
 
 router.post('/getCategoriesUserIsAPartOf', rateLimiters['/getCategoriesUserIsAPartOf'], (req, res) => {
+    let HTTPHeadersSent = false;
     let {skip = 0} = req.body;
     const worker = new Worker(workerPath, {
         workerData: {
@@ -2321,7 +2789,12 @@ router.post('/getCategoriesUserIsAPartOf', rateLimiters['/getCategoriesUserIsAPa
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2331,6 +2804,7 @@ router.post('/getCategoriesUserIsAPartOf', rateLimiters['/getCategoriesUserIsAPa
 });
 
 router.post('/reportPost', rateLimiters['/reportPost'], (req, res) => {
+    let HTTPHeadersSent = false;
     const {postId, postFormat, reason} = req.body
     const worker = new Worker(workerPath, {
         workerData: {
@@ -2340,7 +2814,12 @@ router.post('/reportPost', rateLimiters['/reportPost'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2350,6 +2829,7 @@ router.post('/reportPost', rateLimiters['/reportPost'], (req, res) => {
 });
 
 router.get('/userAlgorithmSettings', rateLimiters['/userAlgorithmSettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'userAlgorithmSettings',
@@ -2358,7 +2838,12 @@ router.get('/userAlgorithmSettings', rateLimiters['/userAlgorithmSettings'], (re
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2368,6 +2853,7 @@ router.get('/userAlgorithmSettings', rateLimiters['/userAlgorithmSettings'], (re
 });
 
 router.post('/uploadAlgorithmSettings', rateLimiters['/uploadAlgorithmSettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'uploadAlgorithmSettings',
@@ -2376,7 +2862,12 @@ router.post('/uploadAlgorithmSettings', rateLimiters['/uploadAlgorithmSettings']
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2386,6 +2877,7 @@ router.post('/uploadAlgorithmSettings', rateLimiters['/uploadAlgorithmSettings']
 });
 
 router.get('/privacySettings', rateLimiters['/privacySettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'privacySettings',
@@ -2394,7 +2886,12 @@ router.get('/privacySettings', rateLimiters['/privacySettings'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2404,6 +2901,7 @@ router.get('/privacySettings', rateLimiters['/privacySettings'], (req, res) => {
 });
 
 router.post('/savePrivacySettings', rateLimiters['/savePrivacySettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'savePrivacySettings',
@@ -2412,7 +2910,12 @@ router.post('/savePrivacySettings', rateLimiters['/savePrivacySettings'], (req, 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2422,6 +2925,7 @@ router.post('/savePrivacySettings', rateLimiters['/savePrivacySettings'], (req, 
 });
 
 router.post('/getProfileStats', rateLimiters['/getProfileStats'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'getProfileStats',
@@ -2430,7 +2934,12 @@ router.post('/getProfileStats', rateLimiters['/getProfileStats'], (req, res) => 
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2440,6 +2949,7 @@ router.post('/getProfileStats', rateLimiters['/getProfileStats'], (req, res) => 
 });
 
 router.get('/loginactivity', rateLimiters['/loginactivity'], (req, res) => {
+    let HTTPHeadersSent = false;
     const authRefreshTokenHeader = req.headers["auth-refresh-token"]
     const worker = new Worker(workerPath, {
         workerData: {
@@ -2449,7 +2959,12 @@ router.get('/loginactivity', rateLimiters['/loginactivity'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2459,6 +2974,7 @@ router.get('/loginactivity', rateLimiters['/loginactivity'], (req, res) => {
 });
 
 router.post('/logoutdevice', rateLimiters['/logoutdevice'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'logoutdevice',
@@ -2467,7 +2983,12 @@ router.post('/logoutdevice', rateLimiters['/logoutdevice'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2477,6 +2998,7 @@ router.post('/logoutdevice', rateLimiters['/logoutdevice'], (req, res) => {
 });
 
 router.post('/logoutallotherdevices', rateLimiters['/logoutallotherdevices'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'logoutallotherdevices',
@@ -2485,7 +3007,12 @@ router.post('/logoutallotherdevices', rateLimiters['/logoutallotherdevices'], (r
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2495,6 +3022,7 @@ router.post('/logoutallotherdevices', rateLimiters['/logoutallotherdevices'], (r
 });
 
 router.get('/loginActivitySettings', rateLimiters['/loginActivitySettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'loginActivitySettings',
@@ -2503,7 +3031,12 @@ router.get('/loginActivitySettings', rateLimiters['/loginActivitySettings'], (re
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2513,6 +3046,7 @@ router.get('/loginActivitySettings', rateLimiters['/loginActivitySettings'], (re
 });
 
 router.post('/uploadLoginActivitySettings', rateLimiters['/uploadLoginActivitySettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'uploadLoginActivitySettings',
@@ -2521,7 +3055,12 @@ router.post('/uploadLoginActivitySettings', rateLimiters['/uploadLoginActivitySe
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2531,6 +3070,7 @@ router.post('/uploadLoginActivitySettings', rateLimiters['/uploadLoginActivitySe
 });
 
 router.post('/updateLoginActivitySettingsOnSignup', rateLimiters['/updateLoginActivitySettingsOnSignup'], HTTPHandler.getDeviceTypeMiddleware(), (req, res) => {
+    let HTTPHeadersSent = false;
     const {newSettings, refreshTokenId} = req.body;
     const worker = new Worker(workerPath, {
         workerData: {
@@ -2540,7 +3080,12 @@ router.post('/updateLoginActivitySettingsOnSignup', rateLimiters['/updateLoginAc
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2550,6 +3095,7 @@ router.post('/updateLoginActivitySettingsOnSignup', rateLimiters['/updateLoginAc
 });
 
 router.get('/followingFeedFilterSettings', rateLimiters['/followingFeedFilterSettings'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'followingFeedFilterSettings',
@@ -2558,7 +3104,12 @@ router.get('/followingFeedFilterSettings', rateLimiters['/followingFeedFilterSet
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {
@@ -2568,6 +3119,7 @@ router.get('/followingFeedFilterSettings', rateLimiters['/followingFeedFilterSet
 });
 
 router.post('/logoutuser', rateLimiters['/logoutuser'], (req, res) => {
+    let HTTPHeadersSent = false;
     const worker = new Worker(workerPath, {
         workerData: {
             functionName: 'logoutuser',
@@ -2576,7 +3128,12 @@ router.post('/logoutuser', rateLimiters['/logoutuser'], (req, res) => {
     })
 
     worker.on('message', (result) => {
-        res.status(result.statusCode).json(result.data)
+        if (!HTTPHeadersSent) {
+            HTTPHeadersSent = true;
+            res.status(result.statusCode).json(result.data)
+        } else {
+            console.error('')
+        }
     })
 
     worker.on('error', (error) => {


### PR DESCRIPTION
If in the case HTTP headers are sent twice, the backend should be able to catch the error instead of crashing.