### PR TITLE
Support Express 5

### DIFF
--- a/api/Conversations.js
+++ b/api/Conversations.js
@@ -40,7 +40,7 @@ var ObjectID = require('mongodb').ObjectID;
 const { tokenValidation } = require("../middleware/TokenHandler");
 
 //UNCOMMENT THE LINE BELOW AFTER CHATS HAVE BEEN REMADE
-//router.all("*", [tokenValidation]); // the * just makes it that it affects them all it could be /whatever and it would affect that only
+//router.all("/{*splat}", [tokenValidation]); // the /{*splat} just makes it that it affects them all it could be /whatever and it would affect that only
 
 //create conversation
 router.post("/create", (req,res)=> {

--- a/api/Messages.js
+++ b/api/Messages.js
@@ -11,7 +11,7 @@ const Conversation = require('../models/Conversation');
 const { tokenValidation } = require("../middleware/TokenHandler");
 
 //UNCOMMENT THE LINE BELOW AFTER CHATS HAVE BEEN REMADE
-//router.all("*", [tokenValidation]); // the * just makes it that it affects them all it could be /whatever and it would affect that only
+//router.all("/{*splat}", [tokenValidation]); // the /{*splat} just makes it that it affects them all it could be /whatever and it would affect that only
 
 //load first 20 or 20 more messages of gc
 router.get("/loadmessages/:conversationId/:lastLoaded", (req,res)=>{

--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@ const server = require('./server')
 
 const port = process.env.PORT || 3000;
 
-server.listen(port, () =>  {
+server.listen(port, (error) =>  {
+    if (error) {
+        throw error
+    }
+    
     console.log(`Server running on port ${port}`);
 })

--- a/routes/Admin.js
+++ b/routes/Admin.js
@@ -36,7 +36,7 @@ router.post('/login', (req, res) => {
     })
 });
 
-router.all("*", [tokenValidation]); // the * just makes it that it affects them all it could be /whatever and it would affect that only
+router.all("/{*splat}", [tokenValidation]); // the /{*splat} just makes it that it affects them all it could be /whatever and it would affect that only
 //All routes below this line will get JWT verification
 
 

--- a/routes/Feed.js
+++ b/routes/Feed.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const { tokenValidation } = require("../middleware/TokenHandler");
 
-router.all("*", [tokenValidation]); // the * just makes it that it affects them all it could be /whatever and it would affect that only
+router.all("/{*splat}", [tokenValidation]); // the /{*splat} just makes it that it affects them all it could be /whatever and it would affect that only
 
 const workerPath = path.resolve('workers', 'FeedWorker.js')
 

--- a/routes/Temp.js
+++ b/routes/Temp.js
@@ -33,7 +33,7 @@ const upload = multer({ storage: storage })
 
 const { tokenValidation } = require("../middleware/TokenHandler");
 
-router.all("*", [tokenValidation]); // the * just makes it that it affects them all it could be /whatever and it would affect that only
+router.all("/{*splat}", [tokenValidation]); // the /{*splat} just makes it that it affects them all it could be /whatever and it would affect that only
 
 const rateLimiters = {
     '/sendnotificationkey': rateLimit({

--- a/server.js
+++ b/server.js
@@ -2100,7 +2100,7 @@ app.get('/checkIfRealSocialSquareServer', (req, res) => {
     })
 })
 
-app.all('*', (req, res) => {
+app.all('/{*splat}', (req, res) => {
   res.status(400).json({
     status: "FAILED",
     message: "Unknown route or method"


### PR DESCRIPTION
The only things needed to be changed to support Express 5 was changing the wildcard path matching syntax for JWT authentication, and adding error handling to app.listen to make sure it throws when an error is passed to the callback function.
This pull request is expected to fail since the main branch uses Express 4, but merging in #500 will make this work.