### PR TITLE
Use single-member replica set for CI

### DIFF
--- a/libraries/MockDBServer.js
+++ b/libraries/MockDBServer.js
@@ -46,7 +46,7 @@ class MockMongoDBServer {
     #startServer() {
         return new Promise(async (resolve, reject) => {
             try {
-                const replSet = await MongoMemoryReplSet.create({ replSet: { count: 3 } });
+                const replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
 
                 this.#replicaSetServer = replSet;
                 this.uri = replSet.getUri();


### PR DESCRIPTION
Explanation for why is in #529